### PR TITLE
Users/charlowu/get default model name in pipeline

### DIFF
--- a/configs/dummy_generative_models/PWM.yaml
+++ b/configs/dummy_generative_models/PWM.yaml
@@ -9,7 +9,7 @@ definitions:
         region_type: IMGT_JUNCTION
         separator: "\t"
   ml_methods:
-    my_pwm_model:
+    model:
       PWM:
         locus: beta
         sequence_type: amino_acid
@@ -20,6 +20,6 @@ instructions:
     type: TrainGenModel
     export_combined_dataset: False
     dataset: dataset
-    method: my_pwm_model
+    method: model
     gen_examples_count: 1000
     number_of_processes: 4

--- a/configs/dummy_generative_models/SoNNia.yaml
+++ b/configs/dummy_generative_models/SoNNia.yaml
@@ -9,20 +9,20 @@ definitions:
         region_type: IMGT_JUNCTION
         separator: "\t"
   ml_methods:
-    my_sonnia_model:
+    model:
       SoNNia:
         batch_size: 10000
         epochs: 50
         default_model_name: 'humanTRB'
         deep: True
         include_joint_genes: True
-        n_gen_seqs: 1000000
+        n_gen_seqs: 1000 #500000
 
 instructions:
   gen_model:
     type: TrainGenModel
     export_combined_dataset: True
     dataset: dataset
-    method: my_sonnia_model
-    gen_examples_count: 1000000
-    number_of_processes: 1
+    method: model
+    gen_examples_count: 1000
+    number_of_processes: 4

--- a/configs/dummy_generative_models/VAE.yaml
+++ b/configs/dummy_generative_models/VAE.yaml
@@ -9,7 +9,7 @@ definitions:
         region_type: IMGT_JUNCTION
         separator: "\t"
   ml_methods:
-    my_vae_model:
+    model:
       SimpleVAE:
         batch_size: 100
         beta: 0.75
@@ -26,18 +26,11 @@ definitions:
         warmup_epochs: 1
         validation_split: 0.1
 
-  reports:
-    my_KLKmerCompare_report: KLKmerComparison
-    my_vae_report:
-      VAESummary:
-        dim_dist_cols: 4
-        dim_dist_rows: None
-
 instructions:
   gen_model:
     type: TrainGenModel
     export_combined_dataset: False
     dataset: dataset
-    method: my_vae_model
+    method: model
     gen_examples_count: 1000
     number_of_processes: 4

--- a/configs/dummy_pipelines/experimental_1.yaml
+++ b/configs/dummy_pipelines/experimental_1.yaml
@@ -15,7 +15,7 @@ models:
       test_dir: "test"
       n_subset_samples: 10
     - name: "sonnia"
-      config: "configs/dummy_generative_models/soNNia.yaml"
+      config: "configs/dummy_generative_models/SoNNia.yaml"
       train_dir: "train"
       test_dir: "test"
       n_subset_samples: 10

--- a/configs/generative_models/LSTM.yaml
+++ b/configs/generative_models/LSTM.yaml
@@ -9,7 +9,7 @@ definitions:
         region_type: IMGT_JUNCTION
         separator: "\t"
   ml_methods:
-    my_lstm_model:
+    model:
         SimpleLSTM:
             locus: beta
             sequence_type: amino_acid
@@ -28,6 +28,6 @@ instructions:
     type: TrainGenModel
     export_combined_dataset: False
     dataset: dataset
-    method: my_lstm_model
+    method: model
     gen_examples_count: 1000000
     number_of_processes: 4

--- a/configs/generative_models/PWM.yaml
+++ b/configs/generative_models/PWM.yaml
@@ -9,7 +9,7 @@ definitions:
         region_type: IMGT_JUNCTION
         separator: "\t"
   ml_methods:
-    my_pwm_model:
+    model:
       PWM:
         locus: beta
         sequence_type: amino_acid
@@ -20,6 +20,6 @@ instructions:
     type: TrainGenModel
     export_combined_dataset: False
     dataset: dataset
-    method: my_pwm_model
+    method: model
     gen_examples_count: 1000000
     number_of_processes: 1

--- a/configs/generative_models/SoNNia.yaml
+++ b/configs/generative_models/SoNNia.yaml
@@ -9,20 +9,20 @@ definitions:
         region_type: IMGT_JUNCTION
         separator: "\t"
   ml_methods:
-    my_sonnia_model:
+    model:
       SoNNia:
         batch_size: 10000
-        epochs: 50 #50
+        epochs: 50
         default_model_name: 'humanTRB'
         deep: True
         include_joint_genes: True
-        n_gen_seqs: 1000 #500000
+        n_gen_seqs: 1000000
 
 instructions:
   gen_model:
     type: TrainGenModel
     export_combined_dataset: True
     dataset: dataset
-    method: my_sonnia_model
-    gen_examples_count: 1000
-    number_of_processes: 4
+    method: model
+    gen_examples_count: 1000000
+    number_of_processes: 1

--- a/configs/generative_models/VAE.yaml
+++ b/configs/generative_models/VAE.yaml
@@ -9,7 +9,7 @@ definitions:
         region_type: IMGT_JUNCTION
         separator: "\t"
   ml_methods:
-    my_vae_model:
+    model:
       SimpleVAE:
         batch_size: 512
         beta: 0.75
@@ -30,6 +30,6 @@ instructions:
     type: TrainGenModel
     export_combined_dataset: False
     dataset: dataset
-    method: my_vae_model
+    method: model
     gen_examples_count: 1000000
     number_of_processes: 1

--- a/configs/pipelines/experimental_1.yaml
+++ b/configs/pipelines/experimental_1.yaml
@@ -1,6 +1,6 @@
-n_experiments: 7
-output_dir: "results/covid_case_control/"
-input_dir: "data/covid_case_control/"
+n_experiments: 9
+output_dir: "results/covid_igh_igk_igl/"
+input_dir: "data/covid_igh_igk_igl/"
 seed: 42
 data_generation:
   experimental: True
@@ -15,10 +15,10 @@ models:
       test_dir: "test"
       n_subset_samples: 100000
     - name: "sonnia"
-      config: "configs/generative_models/soNNia.yaml"
+      config: "configs/generative_models/SoNNia.yaml"
       train_dir: "train"
       test_dir: "test"
-      n_subset_samples: 22000
+      n_subset_samples: 100000
     - name: "vae"
       config: "configs/generative_models/VAE.yaml"
       train_dir: "train"

--- a/gen_airr_bm/core/model_config.py
+++ b/gen_airr_bm/core/model_config.py
@@ -10,6 +10,7 @@ class ModelConfig:
         self.test_dir = test_dir
         self.output_dir = output_dir
         self.n_subset_samples = n_subset_samples
+        self.locus = None
 
     def __repr__(self):
         return (f"ModelConfig(name={self.name}, config={self.config}, experiment={self.experiment}, "

--- a/gen_airr_bm/data_processing/data_generation_methods.py
+++ b/gen_airr_bm/data_processing/data_generation_methods.py
@@ -131,7 +131,10 @@ def preprocess_experimental_umi_data(config: DataGenerationConfig):
     experimental_train_file_path = os.path.join(train_dir, input_path_file_name)
     experimental_test_file_path = os.path.join(test_dir, input_path_file_name)
     experimental_data = pd.read_csv(input_path, sep='\t', usecols=input_columns)
-    experimental_data = experimental_data.dropna(subset=["junction_aa", "v_call", "j_call", "umi_count"])
+    experimental_data = experimental_data[~experimental_data.junction_aa.str.contains("\*")]
+    experimental_data['v_call'] = experimental_data['v_call'].str.split(',').str[0]
+    experimental_data['j_call'] = experimental_data['j_call'].str.split(',').str[0]
+    experimental_data = experimental_data.dropna(subset=["junction_aa", "v_call", "j_call", "umi_count", "locus"])
     experimental_data = experimental_data.loc[experimental_data.index.repeat(experimental_data["umi_count"])]
 
     # we need at least 2 * number_of_sequences sequences to split them into train and test

--- a/gen_airr_bm/training/immuneml_runner.py
+++ b/gen_airr_bm/training/immuneml_runner.py
@@ -4,12 +4,17 @@ import subprocess
 import yaml
 
 
-def write_immuneml_config(input_model_template, input_simulated_data, output_config_file):
+def write_immuneml_config(input_model_template, input_simulated_data, output_config_file, default_model_name=None):
     """Writes an immuneML YAML config by modifying a template."""
     with open(input_model_template, 'r') as file:
         model_template_config = yaml.safe_load(file)
 
     model_template_config['definitions']['datasets']['dataset']['params']['path'] = input_simulated_data
+
+    if default_model_name:
+        config_name = os.path.basename(input_model_template).replace('.yaml', '')
+        if 'default_model_name' in model_template_config['definitions']['ml_methods']['model'][config_name]:
+            model_template_config['definitions']['ml_methods']['model'][config_name]['default_model_name'] = 'human' + default_model_name
 
     with open(output_config_file, 'w') as file:
         yaml.safe_dump(model_template_config, file)


### PR DESCRIPTION
In this pull request we:
- add a few more steps in the preprocessing of experimental data in the data generation 
- extract the default_model_name from each training file to modify the template model config (so that SoNNia can be run correctly on both IGH, IGK, and IGL data in the same pipeline run)